### PR TITLE
待受処理の追加

### DIFF
--- a/conductor/pets_conductor.go
+++ b/conductor/pets_conductor.go
@@ -34,7 +34,7 @@ func ReceiveMessage(svc *sqs.SQS) error {
 		// 一度に取得する最大メッセージ数。最大でも1まで。
 		MaxNumberOfMessages: aws.Int64(1),
 		// これでキューが空の場合はロングポーリング(20秒間繋ぎっぱなし)になる。
-		//		WaitTimeSeconds: aws.Int64(20),
+		WaitTimeSeconds: aws.Int64(20),
 	}
 	resp, err := svc.ReceiveMessage(params)
 
@@ -96,8 +96,9 @@ func ChangeStatus(id string) (Pet, error) {
 // キューを刈り取り、POSTの処理のSTATUSの値を"CREATED"に書き換える
 func GetMessage() {
 	svc := Init()
-	err := ReceiveMessage(svc)
-	if err != nil {
-		log.Fatal(err)
+	for {
+		if err := ReceiveMessage(svc); err != nil {
+			log.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
やったこと(追加機能/直したバグ)
-  go run main.go実行時の連続待ち受け
-  キューが空の場合に20秒間待機状態にするパラメータ追加